### PR TITLE
Adding resizing adjusment support

### DIFF
--- a/jquery.toolbar.js
+++ b/jquery.toolbar.js
@@ -110,7 +110,7 @@ if ( typeof Object.create !== 'function' ) {
             self.coordinates = self.$elem.offset();
 
             if (self.options.adjustment && self.options.adjustment[self.options.position]) {
-                adjustment = self.options.adjustment[self.options.position];
+                adjustment = self.options.adjustment[self.options.position] + adjustment;
             }
 
             switch(self.options.position) {


### PR DESCRIPTION
When using a custom adjustment parameter (great feature, not sure why it is undocumented) the resizing is broken such that it ends up 20 px offset from where it is supposed to be.  This is handled when you have no custom adjustment with 

self.toolbarCss = self.getCoordinates(self.options.position, 20);

However when you use a custom adjustment, this 20 value is lost and the toolbar is improperly shifted
