### PR TITLE
Added option to specify the element that is appended

### DIFF
--- a/jquery.toolbar.js
+++ b/jquery.toolbar.js
@@ -119,8 +119,11 @@ if ( typeof Object.create !== 'function' ) {
         populateContent: function() {
             var self = this;
             var location = self.toolbar.find('.tool-items');
-            var content = $(self.options.content).clone( true ).find('a').addClass('tool-item gradient');
-            location.html(content);
+            var content = $(self.options.content).clone( true );
+            //Add tool-item class to link elements
+            content.find('a').addClass('tool-item gradient');
+            //append all the content
+            location.html(content.find( self.options.elementToAppend || "a" ));
             location.find('.tool-item').on('click', function(event) {
                 event.preventDefault();
                 self.$elem.trigger('toolbarItemClick', this);


### PR DESCRIPTION
Instead of append only the "a" elements inside de toolbar-items, I've added an option to append any element inside the toolbar-items. The new option is "elementToAppend".

This change works with the old code, because by default the element appended is "a".